### PR TITLE
replace calc() with [rem], add padding bottom to app div

### DIFF
--- a/src/pages/edit-profile/index.html
+++ b/src/pages/edit-profile/index.html
@@ -9,7 +9,7 @@
     <script type="module" src="/pages/edit-profile/edit-profile.js"></script>
   </head>
   <body>
-    <div id="app" class="box-border flex flex-col">
+    <div id="app" class="box-border flex flex-col pb-[4.3rem] xs:pb-[5.949375rem] sm:pb-[7.249375rem]">
       <h1 class="sr-only">프로필 카드</h1>
       <!-- 별도의 헤더 없음 -->
 
@@ -18,7 +18,7 @@
       ><!-- navigation: 홈, 게시판, 내 근처, 채팅, 나의 이듬 -->
 
       <div
-        class="fixed top-0 z-50 flex w-full flex-row items-center px-[0.75rem] pb-[0.8125rem] pt-4 xs:px-[1.05rem] xs:pb-[1.1375rem] xs:pt-[1.4rem] sm:px-[1.35rem] sm:pb-[1.4625rem] sm:pt-[1.8rem]"
+        class="fixed top-0 z-50 flex w-full flex-row items-center bg-background px-[0.75rem] pb-[0.8125rem] pt-4 xs:px-[1.05rem] xs:pb-[1.1375rem] xs:pt-[1.4rem] sm:px-[1.35rem] sm:pb-[1.4625rem] sm:pt-[1.8rem]"
       >
         <a
           aria-label="나의 이듬으로 돌아가기"
@@ -28,7 +28,7 @@
         /></a>
       </div>
       <main
-        class="space-y-[0.8125rem] px-[0.75rem] pb-[7.3rem] pt-[2.8125rem] xs:space-y-[1.1375rem] xs:px-[1.05rem] xs:pb-[10.149375rem] xs:pt-[3.9375rem] sm:space-y-[1.4625rem] sm:px-[1.35rem] sm:pb-[12.649375rem] sm:pt-[5.0625rem]"
+        class="space-y-[0.8125rem] px-[0.75rem] pb-[3rem] pt-[2.8125rem] xs:space-y-[1.1375rem] xs:px-[1.05rem] xs:pb-[4.2rem] xs:pt-[3.9375rem] sm:space-y-[1.4625rem] sm:px-[1.35rem] sm:pb-[5.4rem] sm:pt-[5.0625rem]"
       >
         <!-- profile card -->
         <section

--- a/src/pages/profile/index.html
+++ b/src/pages/profile/index.html
@@ -18,23 +18,23 @@
       <main>
         <!-- profile menu -->
         <section
-          class="px-[1.9375rem] pb-[1.125rem] pt-[2.625rem] xs:px-[calc(1.9375rem*1.4)] xs:pb-[calc(1.125rem*1.4)] xs:pt-[calc(2.625rem*1.4)] sm:px-[calc(1.9375rem*1.8)] sm:pb-[calc(1.125rem*1.8)] sm:pt-[calc(2.625rem*1.8)]"
+          class="px-[1.9375rem] pb-[1.125rem] pt-[2.625rem] xs:px-[2.7125rem] xs:pb-[1.575rem] xs:pt-[3.675rem] sm:px-[3.4875rem] sm:pb-[2.025rem] sm:pt-[4.725rem]"
         >
           <div
             id="profileSummary"
-            class="mb-[0.9375rem] flex flex-col items-center xs:mb-[calc(0.9375rem*1.4)] sm:mb-[calc(0.9375rem*1.8)]"
+            class="mb-[0.9375rem] flex flex-col items-center xs:mb-[1.3125rem] sm:mb-[1.6875rem]"
           >
             <img
               src="/assets/avatar-placeholder.png"
               alt="프로필 이미지"
-              class="mb-[0.5625rem] aspect-square w-[21.25vw] rounded-full [box-shadow:0.25rem_0.25rem_0.25rem_0px_rgba(0,_0,_0,_0.10)] xs:mb-[calc(0.5625rem*1.4)] sm:mb-[calc(0.5625rem*1.8)]"
+              class="mb-[0.5625rem] aspect-square w-[21.25vw] rounded-full [box-shadow:0.25rem_0.25rem_0.25rem_0px_rgba(0,_0,_0,_0.10)] xs:mb-[0.7875rem] sm:mb-[1.0125rem]"
             />
-            <div class="flex h-[1.75rem] flex-row items-center xs:h-[calc(1.75rem*1.4)] sm:h-[calc(1.75rem*1.8)]">
+            <div class="flex h-[1.75rem] flex-row items-center xs:h-[2.45rem] sm:h-[3.15rem]">
               <span class="text-lg-group pt-[0.125rem] font-bold leading-[1.5]"
                 ><span class="sr-only">내 닉네임</span>EUID***</span
               >
               <span
-                class="text-sm-group ml-[0.375rem] h-[1.0625rem] rounded-full border-[0.04375rem] border-secondary px-1 leading-[1.6] text-secondary xs:ml-[calc(0.375rem*1.4)] xs:h-[calc(1.0625rem*1.4)] xs:px-2 xs:pt-[0.0625rem] xs:text-base sm:ml-[calc(0.375rem*1.8)]"
+                class="text-sm-group ml-[0.375rem] h-[1.0625rem] rounded-full border-[0.04375rem] border-secondary px-1 leading-[1.6] text-secondary xs:ml-[0.525rem] xs:h-[1.4875rem] xs:px-2 xs:pt-[0.0625rem] xs:text-base sm:ml-[0.675rem]"
                 ><span class="sr-only">내 기수</span>4기</span
               >
             </div>
@@ -46,18 +46,18 @@
           <nav class="mx-auto">
             <ul
               aria-label="프로필 메뉴"
-              class="flex h-[3.25rem] justify-center space-x-[3.875rem] xs:h-[calc(3.25rem*1.4)] xs:space-x-[calc(3.875rem*1.4)] sm:h-[calc(3.25rem*1.8)] sm:space-x-[calc(3.875rem*1.8)]"
+              class="flex h-[3.25rem] justify-center space-x-[3.875rem] xs:h-[4.55rem] xs:space-x-[5.425rem] sm:h-[5.85rem] sm:space-x-[6.975rem]"
             >
               <li>
                 <a
                   href="#"
-                  class="inline-flex h-full w-fit flex-col items-center space-y-[0.4375rem] pt-1 xs:space-y-[calc(0.4375rem*1.4)] xs:pt-[calc(0.25rem*1.4)] sm:space-y-[calc(0.4375rem*1.8)] sm:pt-[calc(0.25rem*1.8)]"
+                  class="inline-flex h-full w-fit flex-col items-center space-y-[0.4375rem] pt-1 xs:space-y-[0.6125rem] xs:pt-[0.35rem] sm:space-y-[0.7875rem] sm:pt-[0.45rem]"
                 >
                   <img
                     aria-hidden="true"
                     src="/assets/icon/qna.svg"
                     alt="qna 아이콘"
-                    class="aspect-square w-[1.625rem] shrink-0 xs:w-[calc(1.625rem*1.4)] sm:w-[calc(1.625rem*1.8)]"
+                    class="aspect-square w-[1.625rem] shrink-0 xs:w-[2.275rem] sm:w-[2.925rem]"
                   />
                   <span class="text-sm-group font-semibold leading-[1.5] text-primary">나의 Q&amp;A</span>
                 </a>
@@ -65,26 +65,26 @@
               <li>
                 <a
                   href="/pages/edit-profile/"
-                  class="inline-flex h-full w-fit flex-col items-center space-y-[0.375rem] xs:space-y-[calc(0.375rem*1.4)] sm:space-y-[calc(0.375rem*1.8)]"
+                  class="inline-flex h-full w-fit flex-col items-center space-y-[0.375rem] xs:space-y-[0.525rem] sm:space-y-[0.675rem]"
                 >
                   <img
                     aria-hidden="true"
                     src="/assets/icon/profile.svg"
                     alt="프로필 아이콘"
-                    class="aspect-square w-[1.875rem] shrink-0 xs:w-[calc(1.875rem*1.4)] sm:w-[calc(1.875rem*1.8)]"
+                    class="aspect-square w-[1.875rem] shrink-0 xs:w-[2.625rem] sm:w-[3.375rem]"
                   /><span class="text-sm-group font-semibold leading-[1.5] text-primary">나의 프로필</span></a
                 >
               </li>
               <li>
                 <a
                   href="#"
-                  class="inline-flex h-full w-fit flex-col items-center space-y-[0.375rem] xs:space-y-[calc(0.375rem*1.4)] sm:space-y-[calc(0.375rem*1.8)]"
+                  class="inline-flex h-full w-fit flex-col items-center space-y-[0.375rem] xs:space-y-[0.525rem] sm:space-y-[0.675rem]"
                 >
                   <img
                     aria-hidden="true"
                     src="/assets/icon/alarm-bell.svg"
                     alt="알림 아이콘"
-                    class="aspect-square w-[1.875rem] shrink-0 xs:w-[calc(1.875rem*1.4)] sm:w-[calc(1.875rem*1.8)]"
+                    class="aspect-square w-[1.875rem] shrink-0 xs:w-[2.625rem] sm:w-[3.375rem]"
                   /><span class="text-sm-group font-semibold leading-[1.5] text-primary">내소식</span>
                 </a>
               </li>
@@ -94,37 +94,29 @@
         <!-- profile menu -->
 
         <!-- passion section -->
-        <section
-          id="passion"
-          class="px-3 pt-3 xs:px-[calc(0.75rem*1.4)] xs:pt-[calc(0.75rem*1.4)] sm:px-[calc(0.75rem*1.8)] sm:pt-[calc(0.75rem*1.8)]"
-        >
+        <section id="passion" class="p-3 xs:p-[1.05rem] sm:p-[1.35rem]">
           <!-- passion temperature -->
-          <div
-            id="passionTemperature"
-            class="-space-y-[0.3125rem] xs:-space-y-[calc(0.3125rem*1.4)] sm:-space-y-[calc(0.3125rem*1.8)]"
-          >
+          <div id="passionTemperature" class="-space-y-[0.3125rem] xs:-space-y-[0.4375rem] sm:-space-y-[0.5625rem]">
             <div class="flex flex-row items-center">
-              <span class="text-[0.75rem] xs:text-[calc(0.75rem*1.4)] sm:text-[calc(0.75rem*1.8)]">열정온도</span>
+              <span class="text-[0.75rem] xs:text-[1.05rem] sm:text-[1.35rem]">열정온도</span>
               <img
                 src="/assets/icon/information.svg"
                 alt="tooltip"
-                class="mb-[0.125rem] aspect-square w-[0.875rem] shrink-0 xs:mb-[calc(0.125rem*1.4)] xs:w-[calc(0.875rem*1.4)] sm:mb-[calc(0.125rem*1.8)] sm:w-[calc(0.875rem*1.8)]"
+                class="mb-[0.125rem] aspect-square w-[0.875rem] shrink-0 xs:mb-[0.175rem] xs:w-[1.225rem] sm:mb-[0.225rem] sm:w-[1.575rem]"
               />
             </div>
 
             <div class="flex flex-col items-end">
               <div
-                class="flex h-[2.1875rem] w-[calc(63.5%+1.9046875rem)] flex-row items-center justify-between xs:h-[calc(2.1875rem*1.4)] xs:w-[calc(63.5%+2.5396875rem)] sm:h-[calc(2.1875rem*1.8)] sm:w-[calc(63.5%+3.3853125rem)]"
+                class="flex h-[2.1875rem] w-[calc(63.5%+1.9046875rem)] flex-row items-center justify-between xs:h-[3.0625rem] xs:w-[calc(63.5%+2.5396875rem)] sm:h-[3.9375rem] sm:w-[calc(63.5%+3.3853125rem)]"
               >
-                <div
-                  class="flex h-[1.4375rem] flex-col items-center xs:h-[calc(1.4375rem*1.4)] sm:h-[calc(1.4375rem*1.8)]"
-                >
+                <div class="flex h-[1.4375rem] flex-col items-center xs:h-[2.0125rem] sm:h-[2.5875rem]">
                   <span class="text-sm-group leading-[1.6] text-contentSecondary">첫 온도 36.5°C</span>
                   <img
                     aria-hidden="true"
                     src="/assets/icon/polygon.svg"
                     alt="아래를 가리키는 삼각형"
-                    class="aspect-[8.8/5] w-[0.55rem] xs:w-[calc(0.55rem*1.4)] sm:w-[calc(0.55rem*1.8)]"
+                    class="aspect-[8.8/5] w-[0.55rem] xs:w-[0.77rem] sm:w-[0.99rem]"
                   />
                 </div>
                 <span class="text-base-group font-semibold text-secondary"
@@ -134,7 +126,7 @@
 
               <div
                 aria-label="percentage bar"
-                class="mb-3 h-[0.51625rem] w-full rounded-full bg-contentSecondary xs:mb-[calc(0.75rem*1.4)] xs:h-[calc(0.51625rem*1.4)] sm:mb-[calc(0.75rem*1.8)] sm:h-[calc(0.51625rem*1.8)]"
+                class="mb-3 h-[0.51625rem] w-full rounded-full bg-contentSecondary xs:mb-[1.05rem] xs:h-[0.72275rem] sm:mb-[1.35rem] sm:h-[0.92925rem]"
               >
                 <div aria-label="41.2%" class="h-full w-[41.2%] rounded-full bg-primary"></div>
               </div>
@@ -145,17 +137,15 @@
           <!-- passion details -->
           <div
             id="passionDetails"
-            class="flex h-[4.4375rem] flex-row px-2 py-4 xs:h-[calc(4.4375rem*1.4)] xs:px-[calc(0.5rem*1.4)] xs:py-[calc(1rem*1.4)] sm:h-[calc(4.4375rem*1.8)] sm:px-[calc(0.5rem*1.8)] sm:py-[calc(1rem*1.8)]"
+            class="flex h-[4.4375rem] flex-row px-2 py-4 xs:h-[6.2125rem] xs:px-[0.7rem] xs:py-[1.4rem] sm:h-[7.9875rem] sm:px-[0.9rem] sm:py-[1.8rem]"
           >
             <div id="ratings" class="flex flex-1 flex-col">
-              <div
-                class="flex flex-row space-x-[0.3125rem] xs:space-x-[calc(0.3125rem*1.4)] sm:space-x-[calc(0.3125rem*1.8)]"
-              >
+              <div class="flex flex-row space-x-[0.3125rem] xs:space-x-[0.4375rem] sm:space-x-[0.5625rem]">
                 <img
                   aria-hidden="true"
                   src="/assets/icon/heart.svg"
                   alt="받은 좋아요"
-                  class="mt-1 h-4 w-4 shrink-0 xs:mt-0 xs:h-[calc(1rem*1.4)] xs:w-[calc(1rem*1.4)] sm:h-[calc(1rem*1.8)] sm:w-[calc(1rem*1.8)]"
+                  class="mt-1 h-4 w-4 shrink-0 xs:mt-0 xs:h-[1.4rem] xs:w-[1.4rem] sm:h-[1.8rem] sm:w-[1.8rem]"
                 />
                 <div class="flex flex-col items-start space-y-[0.3125rem]">
                   <div class="">
@@ -171,14 +161,12 @@
               </div>
             </div>
             <div id="responseRate" class="flex flex-1 flex-col">
-              <div
-                class="flex flex-row space-x-[0.3125rem] xs:space-x-[calc(0.3125rem*1.4)] sm:space-x-[calc(0.3125rem*1.8)]"
-              >
+              <div class="flex flex-row space-x-[0.3125rem] xs:space-x-[0.4375rem] sm:space-x-[0.5625rem]">
                 <img
                   aria-hidden="true"
                   src="/assets/icon/speech.svg"
                   alt="응답률"
-                  class="mt-1 h-4 w-4 shrink-0 xs:mt-0 xs:h-[calc(1rem*1.4)] xs:w-[calc(1rem*1.4)] sm:h-[calc(1rem*1.8)] sm:w-[calc(1rem*1.8)]"
+                  class="mt-1 h-4 w-4 shrink-0 xs:mt-0 xs:h-[1.4rem] xs:w-[1.4rem] sm:h-[1.8rem] sm:w-[1.8rem]"
                 />
                 <div class="flex flex-col items-start space-y-[0.3125rem]">
                   <div>
@@ -201,7 +189,7 @@
           <a
             href="#"
             aria-label="내 활동배지 자세히 보기"
-            class="flex w-full flex-row items-center justify-between px-[1.3125rem] py-4 xs:px-[calc(1.3125rem*1.4)] xs:py-[calc(1rem*1.4)] sm:px-[calc(1.3125rem*1.8)] sm:py-[calc(1rem*1.8)]"
+            class="flex w-full flex-row items-center justify-between px-[1.3125rem] py-4 xs:px-[1.8375rem] xs:py-[1.4rem] sm:px-[2.3625rem] sm:py-[1.8rem]"
           >
             <span class="text-base-group font-semibold leading-[1.5]"
               ><span class="sr-only">내 활동배지 수</span>활동배지 10개</span
@@ -210,7 +198,7 @@
               aria-hidden="true"
               src="/assets/icon/right.svg"
               alt="오른쪽 이동 아이콘"
-              class="aspect-square w-4 xs:w-[calc(1rem*1.4)] sm:w-[calc(1rem*1.8)]"
+              class="aspect-square w-4 xs:w-[1.4rem] sm:w-[1.8rem]"
             />
           </a>
         </section>
@@ -221,14 +209,14 @@
           <a
             href="#"
             aria-label="내 판매상품 바로가기"
-            class="flex w-full flex-row items-center justify-between px-[1.3125rem] py-4 xs:px-[calc(1.3125rem*1.4)] xs:py-[calc(1rem*1.4)] sm:px-[calc(1.3125rem*1.8)] sm:py-[calc(1rem*1.8)]"
+            class="flex w-full flex-row items-center justify-between px-[1.3125rem] py-4 xs:px-[1.8375rem] xs:py-[1.4rem] sm:px-[2.3625rem] sm:py-[1.8rem]"
           >
             <span class="text-base-group font-semibold leading-[1.5]">판매상품 3개</span>
             <img
               aria-hidden="true"
               src="/assets/icon/right.svg"
               alt="오른쪽 이동 아이콘"
-              class="aspect-square w-4 xs:w-[calc(1rem*1.4)] sm:w-[calc(1rem*1.8)]"
+              class="aspect-square w-4 xs:w-[1.4rem] sm:w-[1.8rem]"
             />
           </a>
         </section>
@@ -239,72 +227,72 @@
           <a
             aria-label="받은 매너 평가 자세히 보기"
             href="#"
-            class="flex flex-row items-center justify-between px-[1.3125rem] py-4 xs:px-[calc(1.3125rem*1.4)] xs:py-[calc(1rem*1.4)] sm:px-[calc(1.3125rem*1.8)] sm:py-[calc(1rem*1.8)]"
+            class="flex flex-row items-center justify-between px-[1.3125rem] py-4 xs:px-[1.8375rem] xs:py-[1.4rem] sm:px-[2.3625rem] sm:py-[1.8rem]"
           >
             <span class="text-base-group font-semibold leading-[1.5]">받은 매너 평가</span>
             <img
               aria-hidden="true"
               src="/assets/icon/right.svg"
               alt="오른쪽 이동 아이콘"
-              class="aspect-square w-4 xs:w-[calc(1rem*1.4)] sm:w-[calc(1rem*1.8)]"
+              class="aspect-square w-4 xs:w-[1.4rem] sm:w-[1.8rem]"
             />
           </a>
 
           <!-- manner reviews -->
           <ul
             aria-label="받은 매너 평가 리스트"
-            class="space-y-2 px-[0.625rem] py-[0.875rem] xs:space-y-[calc(0.5rem*1.4)] xs:px-[calc(0.625rem*1.4)] xs:py-[calc(0.875rem*1.4)] sm:space-y-[calc(0.5rem*1.8)] sm:px-[calc(0.625rem*1.8)] sm:py-[calc(0.875rem*1.8)]"
+            class="space-y-2 px-[0.625rem] py-[0.875rem] xs:space-y-[0.7rem] xs:px-[0.875rem] xs:py-[1.225rem] sm:space-y-[0.9rem] sm:px-[1.125rem] sm:py-[1.575rem]"
           >
-            <li class="flex items-center space-x-2 xs:space-x-[calc(0.5rem*1.4)] sm:space-x-[calc(0.5rem*1.8)]">
+            <li class="flex items-center space-x-2 xs:space-x-[0.7rem] sm:space-x-[0.9rem]">
               <img
                 aria-hidden="true"
                 src="/assets/icon/people.svg"
                 alt="평가자 수"
-                class="aspect-square w-4 xs:w-[calc(1rem*1.4)] sm:w-[calc(1rem*1.8)]"
+                class="aspect-square w-4 xs:w-[1.4rem] sm:w-[1.8rem]"
               />
 
               <span
-                class="text-base-group mt-[0.125rem] w-[1.125rem] font-semibold leading-[1.5] xs:mt-[calc(0.125rem*1.4)] xs:w-[calc(1.125rem*1.4)] sm:mt-[calc(0.125rem*1.8)] sm:w-[calc(1.125rem*1.8)]"
+                class="text-base-group mt-[0.125rem] w-[1.125rem] font-semibold leading-[1.5] xs:mt-[0.175rem] xs:w-[1.575rem] sm:mt-[0.225rem] sm:w-[2.025rem]"
                 ><span class="sr-only">평가자 수</span>10</span
               >
               <div
-                class="flex h-[2.375rem] items-center rounded-[0.5rem] rounded-tl-none bg-tertiary p-2 xs:h-[calc(2.375rem*1.4)] xs:rounded-[0.7rem] xs:p-[calc(0.5rem*1.4)] sm:h-[calc(2.375rem*1.8)] sm:rounded-[0.9rem] sm:p-[calc(0.5rem*1.8)]"
+                class="flex h-[2.375rem] items-center rounded-[0.5rem] rounded-tl-none bg-tertiary p-2 xs:h-[3.325rem] xs:rounded-[0.7rem] xs:p-[0.7rem] sm:h-[4.275rem] sm:rounded-[0.9rem] sm:p-[0.9rem]"
               >
                 <span class="text-base-group leading-[1.5]">시간 약속을 잘 지켜요.</span>
               </div>
             </li>
-            <li class="flex items-center space-x-2 xs:space-x-[calc(0.5rem*1.4)] sm:space-x-[calc(0.5rem*1.8)]">
+            <li class="flex items-center space-x-2 xs:space-x-[0.7rem] sm:space-x-[0.9rem]">
               <img
                 aria-hidden="true"
                 src="/assets/icon/people.svg"
                 alt="평가자 수"
-                class="aspect-square w-4 xs:w-[calc(1rem*1.4)] sm:w-[calc(1rem*1.8)]"
+                class="aspect-square w-4 xs:w-[1.4rem] sm:w-[1.8rem]"
               />
 
               <span
-                class="text-base-group mt-[0.125rem] w-[1.125rem] font-semibold leading-[1.5] xs:mt-[calc(0.125rem*1.4)] xs:w-[calc(1.125rem*1.4)] sm:mt-[calc(0.125rem*1.8)] sm:w-[calc(1.125rem*1.8)]"
+                class="text-base-group mt-[0.125rem] w-[1.125rem] font-semibold leading-[1.5] xs:mt-[0.175rem] xs:w-[1.575rem] sm:mt-[0.225rem] sm:w-[2.025rem]"
                 ><span class="sr-only">평가자 수</span>9</span
               >
               <div
-                class="flex h-[2.375rem] items-center rounded-[0.5rem] rounded-tl-none bg-tertiary p-2 xs:h-[calc(2.375rem*1.4)] xs:rounded-[0.7rem] xs:p-[calc(0.5rem*1.4)] sm:h-[calc(2.375rem*1.8)] sm:rounded-[0.9rem] sm:p-[calc(0.5rem*1.8)]"
+                class="flex h-[2.375rem] items-center rounded-[0.5rem] rounded-tl-none bg-tertiary p-2 xs:h-[3.325rem] xs:rounded-[0.7rem] xs:p-[0.7rem] sm:h-[4.275rem] sm:rounded-[0.9rem] sm:p-[0.9rem]"
               >
                 <span class="text-base-group leading-[1.5]">친절하고 매너가 좋아요.</span>
               </div>
             </li>
-            <li class="flex items-center space-x-2 xs:space-x-[calc(0.5rem*1.4)] sm:space-x-[calc(0.5rem*1.8)]">
+            <li class="flex items-center space-x-2 xs:space-x-[0.7rem] sm:space-x-[0.9rem]">
               <img
                 aria-hidden="true"
                 src="/assets/icon/people.svg"
                 alt="평가자 수"
-                class="aspect-square w-4 xs:w-[calc(1rem*1.4)] sm:w-[calc(1rem*1.8)]"
+                class="aspect-square w-4 xs:w-[1.4rem] sm:w-[1.8rem]"
               />
 
               <span
-                class="text-base-group mt-[0.125rem] w-[1.125rem] font-semibold leading-[1.5] xs:mt-[calc(0.125rem*1.4)] xs:w-[calc(1.125rem*1.4)] sm:mt-[calc(0.125rem*1.8)] sm:w-[calc(1.125rem*1.8)]"
+                class="text-base-group mt-[0.125rem] w-[1.125rem] font-semibold leading-[1.5] xs:mt-[0.175rem] xs:w-[1.575rem] sm:mt-[0.225rem] sm:w-[2.025rem]"
                 ><span class="sr-only">평가자 수</span>8</span
               >
               <div
-                class="flex h-[2.375rem] items-center rounded-[0.5rem] rounded-tl-none bg-tertiary p-2 xs:h-[calc(2.375rem*1.4)] xs:rounded-[0.7rem] xs:p-[calc(0.5rem*1.4)] sm:h-[calc(2.375rem*1.8)] sm:rounded-[0.9rem] sm:p-[calc(0.5rem*1.8)]"
+                class="flex h-[2.375rem] items-center rounded-[0.5rem] rounded-tl-none bg-tertiary p-2 xs:h-[3.325rem] xs:rounded-[0.7rem] xs:p-[0.7rem] sm:h-[4.275rem] sm:rounded-[0.9rem] sm:p-[0.9rem]"
               >
                 <span class="text-base-group leading-[1.5]">제가 있는 곳까지 와서 거래했어요.</span>
               </div>
@@ -319,29 +307,27 @@
           <a
             aria-label="받은 거래 후기 모두 보기"
             href="#"
-            class="flex flex-row items-center justify-between border-b-[0.01875rem] border-contentSecondary px-[1.125rem] py-4 xs:px-[calc(1.125rem*1.4)] xs:py-[calc(1rem*1.4)] sm:px-[calc(1.125rem*1.8)] sm:py-[calc(1rem*1.8)]"
+            class="flex flex-row items-center justify-between border-b-[0.01875rem] border-contentSecondary px-[1.125rem] py-4 xs:px-[1.575rem] xs:py-[1.4rem] sm:px-[2.025rem] sm:py-[1.8rem]"
           >
             <span class="text-base-group font-semibold leading-[1.5]">받은 거래 후기 1</span>
             <img
               aria-hidden="true"
               src="/assets/icon/right.svg"
               alt="오른쪽 이동 아이콘"
-              class="aspect-square w-4 xs:w-[calc(1rem*1.4)] sm:w-[calc(1rem*1.8)]"
+              class="aspect-square w-4 xs:w-[1.4rem] sm:w-[1.8rem]"
             />
           </a>
           <!-- reviews list -->
           <ul aria-label="받은 리뷰 리스트">
             <li
-              class="flex items-start justify-between px-[0.625rem] pb-[1.25rem] pt-[0.875rem] xs:px-[calc(0.625rem*1.4)] xs:pb-[calc(1.25rem*1.4)] xs:pt-[calc(0.875rem*1.4)] sm:px-[calc(0.625rem*1.8)] sm:pb-[calc(1.25rem*1.8)] sm:pt-[calc(0.875rem*1.8)]"
+              class="flex items-start justify-between px-[0.625rem] pb-[1.25rem] pt-[0.875rem] xs:px-[0.875rem] xs:pb-[1.75rem] xs:pt-[1.225rem] sm:px-[1.125rem] sm:pb-[2.25rem] sm:pt-[1.575rem]"
             >
-              <div
-                class="flex items-start space-x-[0.5625rem] xs:space-x-[calc(0.5625rem*1.4)] sm:space-x-[calc(0.5625rem*1.8)]"
-              >
+              <div class="flex items-start space-x-[0.5625rem] xs:space-x-[0.7875rem] sm:space-x-[1.0125rem]">
                 <img
                   aria-hidden="true"
                   src="/assets/reviews-avatar-placeholder.png"
                   alt="리뷰 작성자의 프로필 이미지"
-                  class="aspect-square w-7 rounded-full xs:w-[calc(1.75rem*1.4)] sm:w-[calc(1.75rem*1.8)]"
+                  class="aspect-square w-7 rounded-full xs:w-[2.45rem] sm:w-[3.15rem]"
                 />
                 <div class="flex flex-col">
                   <span class="text-sm-group font-semibold leading-[1.5]"
@@ -350,7 +336,7 @@
                   <span class="text-sm-group text-contentSecondary"
                     ><span class="sr-only">리뷰 작성자 정보</span>구매자 · 인천광역시 계양구 · 4개월 전</span
                   >
-                  <span class="text-base-group mt-2 leading-[1.6] xs:mt-[calc(0.5rem*1.4)] sm:mt-[calc(0.5rem*1.8)]"
+                  <span class="text-base-group mt-2 leading-[1.6] xs:mt-[0.7rem] sm:mt-[0.9rem]"
                     ><span class="sr-only">리뷰 작성자가 남긴 리뷰 본문</span>감사감사 감사합니다</span
                   >
                 </div>
@@ -361,7 +347,7 @@
                     aria-hidden="true"
                     src="/assets/icon/more.svg"
                     alt="더보기 아이콘"
-                    class="aspect-square w-5 text-contentSecondary xs:w-[calc(1.25rem*1.4)] sm:w-[calc(1.25rem*1.8)]"
+                    class="aspect-square w-5 text-contentSecondary xs:w-[1.75rem] sm:w-[2.25rem]"
                   />
                 </button>
               </div>
@@ -372,19 +358,19 @@
         <!-- reviews -->
 
         <!-- additional info -->
-        <section id="additional-info" class="pt-[0.4375rem] xs:pt-[calc(0.4375rem*1.4)] sm:pt-[calc(0.4375rem*1.8)]">
+        <section id="additional-info" class="pt-[0.4375rem] xs:pt-[0.6125rem] sm:pt-[0.7875rem]">
           <ul aria-label="부가정보">
             <li class="flex flex-row">
               <a
                 href="#"
-                class="text-base-group w-full py-[0.5625rem] pl-[1.125rem] pr-[0.75rem] leading-[1.6] xs:py-[calc(0.5625rem*1.4)] xs:pl-[calc(1.125rem*1.4)] xs:pr-[calc(0.75rem*1.4)] sm:py-[calc(0.5625rem*1.8)] sm:pl-[calc(1.125rem*1.8)] sm:pr-[calc(0.75rem*1.8)]"
+                class="text-base-group w-full py-[0.5625rem] pl-[1.125rem] pr-[0.75rem] leading-[1.6] xs:py-[0.7875rem] xs:pl-[1.575rem] xs:pr-[1.05rem] sm:py-[1.0125rem] sm:pl-[2.025rem] sm:pr-[1.35rem]"
                 >보관 질문</a
               >
             </li>
             <li class="flex flex-row">
               <a
                 href="#"
-                class="text-base-group w-full py-[0.5625rem] pl-[1.125rem] pr-[0.75rem] leading-[1.6] xs:py-[calc(0.5625rem*1.4)] xs:pl-[calc(1.125rem*1.4)] xs:pr-[calc(0.75rem*1.4)] sm:py-[calc(0.5625rem*1.8)] sm:pl-[calc(1.125rem*1.8)] sm:pr-[calc(0.75rem*1.8)]"
+                class="text-base-group w-full py-[0.5625rem] pl-[1.125rem] pr-[0.75rem] leading-[1.6] xs:py-[0.7875rem] xs:pl-[1.575rem] xs:pr-[1.05rem] sm:py-[1.0125rem] sm:pl-[2.025rem] sm:pr-[1.35rem]"
                 >설정</a
               >
             </li>
@@ -392,7 +378,7 @@
             <li class="flex flex-row">
               <a
                 href="#"
-                class="text-base-group w-full py-[0.5625rem] pl-[1.125rem] pr-[0.75rem] leading-[1.6] xs:py-[calc(0.5625rem*1.4)] xs:pl-[calc(1.125rem*1.4)] xs:pr-[calc(0.75rem*1.4)] sm:py-[calc(0.5625rem*1.8)] sm:pl-[calc(1.125rem*1.8)] sm:pr-[calc(0.75rem*1.8)]"
+                class="text-base-group w-full py-[0.5625rem] pl-[1.125rem] pr-[0.75rem] leading-[1.6] xs:py-[0.7875rem] xs:pl-[1.575rem] xs:pr-[1.05rem] sm:py-[1.0125rem] sm:pl-[2.025rem] sm:pr-[1.35rem]"
                 >지식 iN 공식 블로그</a
               >
             </li>
@@ -400,21 +386,21 @@
             <li class="flex flex-row">
               <a
                 href="#"
-                class="text-base-group w-full py-[0.5625rem] pl-[1.125rem] pr-[0.75rem] leading-[1.6] xs:py-[calc(0.5625rem*1.4)] xs:pl-[calc(1.125rem*1.4)] xs:pr-[calc(0.75rem*1.4)] sm:py-[calc(0.5625rem*1.8)] sm:pl-[calc(1.125rem*1.8)] sm:pr-[calc(0.75rem*1.8)]"
+                class="text-base-group w-full py-[0.5625rem] pl-[1.125rem] pr-[0.75rem] leading-[1.6] xs:py-[0.7875rem] xs:pl-[1.575rem] xs:pr-[1.05rem] sm:py-[1.0125rem] sm:pl-[2.025rem] sm:pr-[1.35rem]"
                 >서비스 정보</a
               >
             </li>
             <li class="flex flex-row">
               <a
                 href="#"
-                class="text-base-group w-full py-[0.5625rem] pl-[1.125rem] pr-[0.75rem] leading-[1.6] xs:py-[calc(0.5625rem*1.4)] xs:pl-[calc(1.125rem*1.4)] xs:pr-[calc(0.75rem*1.4)] sm:py-[calc(0.5625rem*1.8)] sm:pl-[calc(1.125rem*1.8)] sm:pr-[calc(0.75rem*1.8)]"
+                class="text-base-group w-full py-[0.5625rem] pl-[1.125rem] pr-[0.75rem] leading-[1.6] xs:py-[0.7875rem] xs:pl-[1.575rem] xs:pr-[1.05rem] sm:py-[1.0125rem] sm:pl-[2.025rem] sm:pr-[1.35rem]"
                 >공지사항</a
               >
             </li>
             <li class="flex flex-row">
               <a
                 href="#"
-                class="text-base-group flex w-full flex-row justify-between py-[0.5625rem] pl-[1.125rem] pr-[0.75rem] leading-[1.6] xs:py-[calc(0.5625rem*1.4)] xs:pl-[calc(1.125rem*1.4)] xs:pr-[calc(0.75rem*1.4)] sm:py-[calc(0.5625rem*1.8)] sm:pl-[calc(1.125rem*1.8)] sm:pr-[calc(0.75rem*1.8)]"
+                class="text-base-group flex w-full flex-row justify-between py-[0.5625rem] pl-[1.125rem] pr-[0.75rem] leading-[1.6] xs:py-[0.7875rem] xs:pl-[1.575rem] xs:pr-[1.05rem] sm:py-[1.0125rem] sm:pl-[2.025rem] sm:pr-[1.35rem]"
                 ><span>로그아웃</span
                 ><span class="text-secondary"><span class="sr-only">현재 사용자</span>kimchihi</span></a
               >

--- a/src/pages/profile/index.html
+++ b/src/pages/profile/index.html
@@ -9,7 +9,7 @@
     <script type="module" src="/pages/profile/profile.js"></script>
   </head>
   <body>
-    <div id="app" class="box-border flex flex-col">
+    <div id="app" class="box-border flex flex-col pb-[4.3rem] xs:pb-[5.949375rem] sm:pb-[7.249375rem]">
       <h1 class="sr-only">나의 이듬</h1>
       <!-- 별도의 헤더 없음 -->
       <!-- navigation: 홈, 게시판, 내 근처, 채팅, 나의 이듬 -->
@@ -372,10 +372,7 @@
         <!-- reviews -->
 
         <!-- additional info -->
-        <section
-          id="additional-info"
-          class="pb-[4.3rem] pt-[0.4375rem] xs:pb-[5.949375rem] xs:pt-[calc(0.4375rem*1.4)] sm:pb-[7.249375rem] sm:pt-[calc(0.4375rem*1.8)]"
-        >
+        <section id="additional-info" class="pt-[0.4375rem] xs:pt-[calc(0.4375rem*1.4)] sm:pt-[calc(0.4375rem*1.8)]">
           <ul aria-label="부가정보">
             <li class="flex flex-row">
               <a


### PR DESCRIPTION
## PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
calc()함수를 사용한 곳을 규칙에 맞게 모두 연산 완료된 값으로 대체.
다만, progress bar의 36.5%위치에 첫 온도를 배치해야 했기에 그 부분은 그대로 calc 함수를 사용함.
(사진 첨부)

<img width="1462" alt="스크린샷 2024-07-11 오후 12 51 06" src="https://github.com/FRONTENDSCHOOL10/coding13-euid/assets/61109672/f99587b2-38c7-4ad3-be6e-817d9652d95f">


## 이슈
<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->
resolves #54 