### PR TITLE
프로필페이지 로그아웃 버튼 구현

### DIFF
--- a/src/pages/login/login.js
+++ b/src/pages/login/login.js
@@ -1,0 +1,43 @@
+import pb from '/api/pocketbase';
+
+function login() {
+  const phoneInput = document.querySelector('#phone-number');
+  const verifyButton = document.querySelector('button');
+  const phoneRegex = /^\d{10,11}$/;
+  let verificationCode;
+
+  /* --------------------------------- 전화번호 검증 -------------------------------- */
+  phoneInput.addEventListener('input', () => {
+    const isValid = phoneRegex.test(phoneInput.value);
+    // 유효하지 않으면 버튼 비활성화
+    verifyButton.disabled = !isValid;
+
+    if (isValid) {
+      verifyButton.classList.remove('border-contentSecondary', 'text-contentSecondary');
+      verifyButton.classList.add('border-black', 'text-black');
+    } else {
+      verifyButton.classList.remove('border-black', 'text-black');
+      verifyButton.classList.add('border-contentSecondary', 'text-contentSecondary');
+    }
+  });
+
+  verifyButton.addEventListener('click', () => {
+    const phoneNumber = phoneInput.value;
+
+    if (!verifyButton.disabled) {
+      // 6자리 랜덤 코드
+      const verificationCode = Math.floor(100000 + Math.random() * 900000);
+
+      localStorage.setItem('phoneNumber', phoneInput.value);
+      localStorage.setItem('verificationCode', verificationCode);
+
+      // 임시
+      alert(`인증 코드: ${verificationCode}`);
+
+      // signup2.html로 이동 (인증번호 입력하는 페이지로 이동)
+      window.location.href = '/pages/login/login2.html';
+    }
+  });
+}
+
+login();

--- a/src/pages/login/login2.html
+++ b/src/pages/login/login2.html
@@ -6,7 +6,7 @@
     <title>Enter EUID</title>
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="stylesheet" href="/styles/tailwind.css" />
-    <script type="module" src="/pages/login/login.js"></script>
+    <script type="module" src="/pages/login/login2.js"></script>
   </head>
   <body>
     <div id="app" class="mx-auto">
@@ -45,6 +45,7 @@
         >
 
         <button
+          id="login"
           type="button"
           class="text-base-group mb-3 w-full rounded-lg border-[0.03125rem] border-solid border-contentSecondary bg-contentSecondary py-3 font-semibold text-white xs:mb-[1.05rem] xs:py-[1.05rem] sm:mb-[1.35rem] sm:py-[0.9rem]"
         >

--- a/src/pages/login/login2.html
+++ b/src/pages/login/login2.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Enter EUID</title>
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="stylesheet" href="/styles/tailwind.css" />
+    <script type="module" src="/pages/login/login.js"></script>
+  </head>
+  <body>
+    <div id="app" class="mx-auto">
+      <nav class="flex h-9 xs:h-[3.15rem] sm:h-[4.05rem]">
+        <a href="/pages/start/index.html"
+          ><img
+            class="my-2 ml-3 h-5 w-5 xs:my-[0.7rem] xs:ml-[1.05rem] xs:h-[1.75rem] xs:w-[1.75rem] sm:my-[0.9rem] sm:ml-[1.35rem] sm:h-[2.25rem] sm:w-[2.25rem]"
+            src="/icon/direction-left.svg"
+            alt="이전 페이지로 돌아가기"
+        /></a>
+      </nav>
+
+      <form class="mx-3 flex flex-col items-center xs:mx-[1.05rem] sm:mx-[1.35rem]">
+        <label for="input-phone-number" class="sr-only">입력한 전화번호</label>
+        <input
+          type="number"
+          id="input-phone-number"
+          class="text-base-group mb-3 w-full rounded border border-black py-2 pl-3 font-normal focus:border-[0.03125rem] focus:border-solid focus:border-black focus:placeholder:text-black xs:mb-[1.05rem] xs:py-[0.7rem] xs:pl-[1.05rem] sm:mb-[1.35rem] sm:py-[0.9rem] sm:pl-[1.35rem]"
+          disabled
+        />
+        <button
+          type="button"
+          class="text-base-group mb-3 w-full rounded border-[0.03125rem] border-solid border-contentSecondary bg-white py-2 font-semibold xs:mb-[1.05rem] xs:py-[0.7rem] sm:mb-[1.35rem] sm:py-[0.9rem]"
+        >
+          인증문자 다시 받기
+        </button>
+        <label for="verification-number" class="sr-only">인증번호 입력하기</label>
+        <input
+          type="number"
+          placeholder="인증번호 입력"
+          id="verification-number"
+          class="text-base-group w-full rounded border border-black py-2 pl-3 font-normal focus:border-[0.03125rem] focus:border-solid focus:border-black focus:placeholder:text-black xs:py-[0.7rem] xs:pl-[1.05rem] sm:py-[0.9rem] sm:pl-[1.35rem]"
+        />
+        <span class="text-sm-group mb-3 self-start text-contentSecondary xs:mb-[1.05rem] sm:mb-[1.35rem]"
+          >어떤 경우에도 타인에게 공유하지 마세요!</span
+        >
+
+        <button
+          type="button"
+          class="text-base-group mb-3 w-full rounded-lg border-[0.03125rem] border-solid border-contentSecondary bg-contentSecondary py-3 font-semibold text-white xs:mb-[1.05rem] xs:py-[1.05rem] sm:mb-[1.35rem] sm:py-[0.9rem]"
+        >
+          동의하고 시작하기
+        </button>
+        <!-- <a href="/pages/" class="underline text-contentSecondary underline-offset-2">인증번호가 오지 않아요?</a> -->
+      </form>
+    </div>
+  </body>
+</html>

--- a/src/pages/login/login2.js
+++ b/src/pages/login/login2.js
@@ -1,0 +1,29 @@
+import { UserService } from '@/service/UserService';
+
+function login2() {
+  const verificationNumberInput = document.querySelector('#verification-number');
+  const loginButton = document.querySelector('#login');
+  const phoneNumber = localStorage.getItem('phoneNumber');
+
+  loginButton.addEventListener('click', async () => {
+    const localStorageVerificationCode = localStorage.getItem('verificationCode');
+    const verificationCode = verificationNumberInput.value;
+
+    if (verificationCode && verificationCode === localStorageVerificationCode) {
+      try {
+        await UserService.login(phoneNumber);
+      } catch (error) {
+        alert(`오류가 발생했습니다, 다시 시도해주세요: ${error.message}`);
+        window.location.href = '/pages/login/';
+        return;
+      }
+
+      // 로그인 성공 시 자동으로 메인화면으로 이동.
+      window.location.href = '/';
+    } else {
+      alert(`인증 코드: 잘못된 코드입니다.`);
+    }
+  });
+}
+
+login2();

--- a/src/pages/profile/index.html
+++ b/src/pages/profile/index.html
@@ -32,7 +32,7 @@
             />
             <div class="flex h-[1.75rem] flex-row items-center xs:h-[2.45rem] sm:h-[3.15rem]">
               <span class="text-lg-group pt-[0.125rem] font-bold leading-[1.5]"
-                ><span class="sr-only">내 닉네임</span>EUID***</span
+                ><span class="sr-only">내 닉네임</span><span id="username">EUID***</span></span
               >
               <span
                 class="text-sm-group ml-[0.375rem] h-[1.0625rem] rounded-full border-[0.04375rem] border-secondary px-1 leading-[1.6] text-secondary xs:ml-[0.525rem] xs:h-[1.4875rem] xs:px-2 xs:pt-[0.0625rem] xs:text-base sm:ml-[0.675rem]"

--- a/src/pages/profile/index.html
+++ b/src/pages/profile/index.html
@@ -32,8 +32,8 @@
             />
             <div class="flex h-[1.75rem] flex-row items-center xs:h-[2.45rem] sm:h-[3.15rem]">
               <span class="text-lg-group pt-[0.125rem] font-bold leading-[1.5]"
-                ><span class="sr-only">내 닉네임</span><span id="username">EUID***</span></span
-              >
+                ><span class="sr-only">내 닉네임</span><span id="username"></span
+              ></span>
               <span
                 class="text-sm-group ml-[0.375rem] h-[1.0625rem] rounded-full border-[0.04375rem] border-secondary px-1 leading-[1.6] text-secondary xs:ml-[0.525rem] xs:h-[1.4875rem] xs:px-2 xs:pt-[0.0625rem] xs:text-base sm:ml-[0.675rem]"
                 ><span class="sr-only">내 기수</span>4기</span
@@ -399,12 +399,16 @@
               >
             </li>
             <li class="flex flex-row">
-              <a
-                href="#"
+              <button
+                id="logout"
+                type="button"
                 class="text-base-group flex w-full flex-row justify-between py-[0.5625rem] pl-[1.125rem] pr-[0.75rem] leading-[1.6] xs:py-[0.7875rem] xs:pl-[1.575rem] xs:pr-[1.05rem] sm:py-[1.0125rem] sm:pl-[2.025rem] sm:pr-[1.35rem]"
-                ><span>로그아웃</span
-                ><span class="text-secondary"><span class="sr-only">현재 사용자</span>kimchihi</span></a
               >
+                <span>로그아웃</span
+                ><span class="text-secondary"
+                  ><span class="sr-only">현재 사용자</span><span id="logout-button__username"></span
+                ></span>
+              </button>
             </li>
           </ul>
         </section>

--- a/src/pages/profile/profile.js
+++ b/src/pages/profile/profile.js
@@ -1,0 +1,11 @@
+import { UserService } from '@/service/UserService';
+
+async function profile() {
+  const currentUser = await UserService.currentUser();
+  console.log('currentUser', currentUser);
+
+  const usernameSpan = document.querySelector('#username');
+  usernameSpan.textContent = currentUser.username;
+}
+
+profile();

--- a/src/pages/profile/profile.js
+++ b/src/pages/profile/profile.js
@@ -1,11 +1,21 @@
 import { UserService } from '@/service/UserService';
 
+function handleLogout() {
+  UserService.logout();
+}
+
 async function profile() {
   const currentUser = await UserService.currentUser();
   console.log('currentUser', currentUser);
 
   const usernameSpan = document.querySelector('#username');
   usernameSpan.textContent = currentUser.username;
+
+  const logoutButton = document.querySelector('#logout');
+  logoutButton.addEventListener('click', handleLogout);
+
+  const logoutButtonSpan = document.querySelector('#logout-button__username');
+  logoutButtonSpan.textContent = currentUser.username;
 }
 
 profile();

--- a/src/pages/signup/index.html
+++ b/src/pages/signup/index.html
@@ -6,7 +6,7 @@
     <title>Enter EUID</title>
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="stylesheet" href="/styles/tailwind.css" />
-    <script type="module" src="/pages/login/login.js"></script>
+    <script type="module" src="/pages/signup/signup.js"></script>
   </head>
   <body>
     <div id="app" class="mx-auto">
@@ -19,8 +19,8 @@
         /></a>
       </nav>
       <section class="ml-3 mt-3 xs:ml-[1.05rem] xs:mt-[1.05rem] sm:ml-[1.35rem] sm:mt-[1.35rem]">
-        <p class="text-lg-group font-semibold">안녕하세요!</p>
-        <h1 class="text-lg-group font-semibold">휴대폰 번호로 가입해주세요.</h1>
+        <p class="font-semibold text-lg-group">안녕하세요!</p>
+        <h1 class="font-semibold text-lg-group">휴대폰 번호로 가입해주세요.</h1>
         <p class="text-sm-group mb-[1.44rem] inline-block xs:mb-[2.016rem] sm:mb-[2.592rem]">
           휴대폰 번호는 안전하게 보관되며 서로에게 공개되지 않아요.
         </p>

--- a/src/pages/signup/signup.js
+++ b/src/pages/signup/signup.js
@@ -21,21 +21,27 @@ function signup() {
     }
   });
 
-  verifyButton.addEventListener('click', () => {
+  verifyButton.addEventListener('click', async () => {
     const phoneNumber = phoneInput.value;
 
     if (!verifyButton.disabled) {
       // 6자리 랜덤 코드
       const verificationCode = Math.floor(100000 + Math.random() * 900000);
 
-      localStorage.setItem('phoneNumber', phoneInput.value);
-      localStorage.setItem('verificationCode', verificationCode);
+      try {
+        const newUser = await pb.collection('users').create({
+          phone_number: phoneNumber,
+        });
 
-      // 임시
-      alert(`인증 코드: ${verificationCode}`);
+        localStorage.setItem('phoneNumber', phoneInput.value);
+        localStorage.setItem('verificationCode', verificationCode);
 
-      // signup2.html로 이동 (인증번호 입력하는 페이지로 이동)
-      window.location.href = '/pages/signup/signup2.html';
+        alert(`인증 코드: ${verificationCode}`);
+        // signup2.html로 이동 (인증번호 입력하는 페이지로 이동)
+        window.location.href = '/pages/signup/signup2.html';
+      } catch (error) {
+        console.error('새 사용자 생성 중 오류 발생:', error);
+      }
     }
   });
 }

--- a/src/pages/signup/signup.js
+++ b/src/pages/signup/signup.js
@@ -21,27 +21,21 @@ function signup() {
     }
   });
 
-  verifyButton.addEventListener('click', async () => {
+  verifyButton.addEventListener('click', () => {
     const phoneNumber = phoneInput.value;
 
     if (!verifyButton.disabled) {
       // 6자리 랜덤 코드
       const verificationCode = Math.floor(100000 + Math.random() * 900000);
 
-      try {
-        const newUser = await pb.collection('users').create({
-          phone_number: phoneNumber,
-        });
+      localStorage.setItem('phoneNumber', phoneInput.value);
+      localStorage.setItem('verificationCode', verificationCode);
 
-        localStorage.setItem('phoneNumber', phoneInput.value);
-        localStorage.setItem('verificationCode', verificationCode);
+      // 임시
+      alert(`인증 코드: ${verificationCode}`);
 
-        alert(`인증 코드: ${verificationCode}`);
-        // signup2.html로 이동 (인증번호 입력하는 페이지로 이동)
-        window.location.href = '/pages/signup/signup2.html';
-      } catch (error) {
-        console.error('새 사용자 생성 중 오류 발생:', error);
-      }
+      // signup2.html로 이동 (인증번호 입력하는 페이지로 이동)
+      window.location.href = '/pages/signup/signup2.html';
     }
   });
 }

--- a/src/pages/signup/signup.js
+++ b/src/pages/signup/signup.js
@@ -1,0 +1,43 @@
+import pb from '/api/pocketbase';
+
+function signup() {
+  const phoneInput = document.querySelector('#phone-number');
+  const verifyButton = document.querySelector('button');
+  const phoneRegex = /^\d{10,11}$/;
+  let verificationCode;
+
+  /* --------------------------------- 전화번호 검증 -------------------------------- */
+  phoneInput.addEventListener('input', () => {
+    const isValid = phoneRegex.test(phoneInput.value);
+    // 유효하지 않으면 버튼 비활성화
+    verifyButton.disabled = !isValid;
+
+    if (isValid) {
+      verifyButton.classList.remove('border-contentSecondary', 'text-contentSecondary');
+      verifyButton.classList.add('border-black', 'text-black');
+    } else {
+      verifyButton.classList.remove('border-black', 'text-black');
+      verifyButton.classList.add('border-contentSecondary', 'text-contentSecondary');
+    }
+  });
+
+  verifyButton.addEventListener('click', () => {
+    const phoneNumber = phoneInput.value;
+
+    if (!verifyButton.disabled) {
+      // 6자리 랜덤 코드
+      const verificationCode = Math.floor(100000 + Math.random() * 900000);
+
+      localStorage.setItem('phoneNumber', phoneInput.value);
+      localStorage.setItem('verificationCode', verificationCode);
+
+      // 임시
+      alert(`인증 코드: ${verificationCode}`);
+
+      // signup2.html로 이동 (인증번호 입력하는 페이지로 이동)
+      window.location.href = '/pages/signup/signup2.html';
+    }
+  });
+}
+
+signup();

--- a/src/pages/signup/signup2.html
+++ b/src/pages/signup/signup2.html
@@ -6,7 +6,7 @@
     <title>Enter EUID</title>
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="stylesheet" href="/styles/tailwind.css" />
-    <script type="module" src="/pages/signup/signup.js"></script>
+    <script type="module" src="/pages/signup/signup2.js"></script>
   </head>
   <body>
     <div id="app" class="mx-auto">
@@ -45,6 +45,7 @@
         >
 
         <button
+          id="agree"
           type="button"
           class="text-base-group mb-3 w-full rounded-lg border-[0.03125rem] border-solid border-contentSecondary bg-contentSecondary py-3 font-semibold text-white xs:mb-[1.05rem] xs:py-[1.05rem] sm:mb-[1.35rem] sm:py-[0.9rem]"
         >

--- a/src/pages/signup/signup2.html
+++ b/src/pages/signup/signup2.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Enter EUID</title>
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="stylesheet" href="/styles/tailwind.css" />
+    <script type="module" src="/pages/signup/signup.js"></script>
+  </head>
+  <body>
+    <div id="app" class="mx-auto">
+      <nav class="flex h-9 xs:h-[3.15rem] sm:h-[4.05rem]">
+        <a href="/pages/category/index.html"
+          ><img
+            class="my-2 ml-3 h-5 w-5 xs:my-[0.7rem] xs:ml-[1.05rem] xs:h-[1.75rem] xs:w-[1.75rem] sm:my-[0.9rem] sm:ml-[1.35rem] sm:h-[2.25rem] sm:w-[2.25rem]"
+            src="/icon/direction-left.svg"
+            alt="이전 페이지로 돌아가기"
+        /></a>
+      </nav>
+
+      <form class="mx-3 flex flex-col items-center xs:mx-[1.05rem] sm:mx-[1.35rem]">
+        <label for="input-phone-number" class="sr-only">입력한 전화번호</label>
+        <input
+          type="number"
+          id="input-phone-number"
+          class="text-base-group mb-3 w-full rounded border border-black py-2 pl-3 font-normal focus:border-[0.03125rem] focus:border-solid focus:border-black focus:placeholder:text-black xs:mb-[1.05rem] xs:py-[0.7rem] xs:pl-[1.05rem] sm:mb-[1.35rem] sm:py-[0.9rem] sm:pl-[1.35rem]"
+          disabled
+        />
+        <button
+          type="button"
+          class="text-base-group mb-3 w-full rounded border-[0.03125rem] border-solid border-contentSecondary bg-white py-2 font-semibold xs:mb-[1.05rem] xs:py-[0.7rem] sm:mb-[1.35rem] sm:py-[0.9rem]"
+        >
+          인증문자 다시 받기
+        </button>
+        <label for="verification-number" class="sr-only">인증번호 입력하기</label>
+        <input
+          type="number"
+          placeholder="인증번호 입력"
+          id="verification-number"
+          class="text-base-group w-full rounded border border-black py-2 pl-3 font-normal focus:border-[0.03125rem] focus:border-solid focus:border-black focus:placeholder:text-black xs:py-[0.7rem] xs:pl-[1.05rem] sm:py-[0.9rem] sm:pl-[1.35rem]"
+        />
+        <span class="text-sm-group mb-3 self-start text-contentSecondary xs:mb-[1.05rem] sm:mb-[1.35rem]"
+          >어떤 경우에도 타인에게 공유하지 마세요!</span
+        >
+
+        <button
+          type="button"
+          class="text-base-group mb-3 w-full rounded-lg border-[0.03125rem] border-solid border-contentSecondary bg-contentSecondary py-3 font-semibold text-white xs:mb-[1.05rem] xs:py-[1.05rem] sm:mb-[1.35rem] sm:py-[0.9rem]"
+        >
+          동의하고 시작하기
+        </button>
+        <!-- <a href="/pages/" class="underline text-contentSecondary underline-offset-2">인증번호가 오지 않아요?</a> -->
+      </form>
+    </div>
+  </body>
+</html>

--- a/src/pages/signup/signup2.js
+++ b/src/pages/signup/signup2.js
@@ -14,7 +14,7 @@ function signup2() {
         await UserService.registerUser(phoneNumber);
         await UserService.login(phoneNumber);
       } catch (error) {
-        if (error?.originalError?.data?.data?.phone_number?.code === 'validation_not_unique') {
+        if (error?.response?.data?.phone_number?.code === 'validation_not_unique') {
           alert(`이미 이 번호로 가입된 사용자가 있습니다. 로그인해주세요.`);
           window.location.href = '/pages/login/';
         } else {

--- a/src/pages/signup/signup2.js
+++ b/src/pages/signup/signup2.js
@@ -1,0 +1,35 @@
+import { UserService } from '@/service/UserService';
+
+function signup2() {
+  const verificationNumberInput = document.querySelector('#verification-number');
+  const agreeButton = document.querySelector('#agree');
+  const phoneNumber = localStorage.getItem('phoneNumber');
+
+  agreeButton.addEventListener('click', async () => {
+    const localStorageVerificationCode = localStorage.getItem('verificationCode');
+    const verificationCode = verificationNumberInput.value;
+
+    if (verificationCode && verificationCode === localStorageVerificationCode) {
+      try {
+        await UserService.registerUser(phoneNumber);
+        await UserService.login(phoneNumber);
+      } catch (error) {
+        if (error?.originalError?.data?.data?.phone_number?.code === 'validation_not_unique') {
+          alert(`이미 이 번호로 가입된 사용자가 있습니다. 로그인해주세요.`);
+          window.location.href = '/pages/login/';
+        } else {
+          alert(`오류가 발생했습니다, 다시 시도해주세요: ${error.message}`);
+          window.location.href = '/pages/signup/';
+        }
+        return;
+      }
+
+      // 로그인 성공 시 자동으로 메인화면으로 이동.
+      window.location.href = '/';
+    } else {
+      alert(`인증 코드: 잘못된 코드입니다.`);
+    }
+  });
+}
+
+signup2();

--- a/src/service/UserService.js
+++ b/src/service/UserService.js
@@ -1,0 +1,49 @@
+import pb from '@/api/pocketbase';
+
+export class UserService {
+  static initializeState(state) {}
+
+  static async currentUser(shouldRedirect = true) {
+    // https://github.com/pocketbase/pocketbase/discussions/1390#discussioncomment-4498324
+    if (pb.authStore.isValid) {
+      try {
+        // 많이 느림, await 대신 async로 그냥.. 데이터를 나중에 rerender해야하나...
+        await pb.collection('users').authRefresh();
+
+        return pb.authStore.model;
+      } catch (error) {
+        pb.authStore.clear();
+      }
+    }
+
+    if (shouldRedirect) {
+      window.location.href = '/pages/start/';
+    } else {
+      return null;
+    }
+  }
+
+  static async login(phoneNumber) {
+    // 우리는 username과 pw를 이용해 로그인하는 방식이 아님. 우리가 알고 있는 유일한 정보는 휴대폰 번호기 때문에 그것을 이용해 해당 휴대폰 번호를 가진 유저를 찾아, 그 유저의 포켓베이스에 등록된 username을 가져옴, pw는 phone_number과 동일하게 설정해둠.
+    const user = await pb.collection('users').getFirstListItem(`phone_number="${phoneNumber}"`);
+
+    if (!user) {
+      return null;
+    }
+
+    // 비밀번호는 우선 휴대폰 번호로 설정
+    const authData = await pb.collection('users').authWithPassword(user.username, phoneNumber);
+
+    // model = user
+    return authData.model;
+  }
+
+  static async registerUser(phoneNumber) {
+    const user = await pb.collection('users').create({
+      phone_number: phoneNumber,
+      password: phoneNumber,
+      passwordConfirm: phoneNumber,
+    });
+    return user;
+  }
+}

--- a/src/service/UserService.js
+++ b/src/service/UserService.js
@@ -3,6 +3,7 @@ import pb from '@/api/pocketbase';
 export class UserService {
   static initializeState(state) {}
 
+  /** 페이지별로 한 번씩만 불러와서 재사용하기 */
   static async currentUser(shouldRedirect = true) {
     // https://github.com/pocketbase/pocketbase/discussions/1390#discussioncomment-4498324
     if (pb.authStore.isValid) {
@@ -21,6 +22,11 @@ export class UserService {
     } else {
       return null;
     }
+  }
+
+  static logout() {
+    pb.authStore.clear();
+    window.location.href = '/pages/start/';
   }
 
   static async login(phoneNumber) {


### PR DESCRIPTION
## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
로그아웃 버튼을 구현했습니다.
프로필 페이지에 들어가 스크롤을 내리면 제일 하단에 있는 로그아웃을 a태그에서 button 태그로 변경 후 로그아웃 기능을 추가했고,
버튼을 누름과 동시에 start 페이지로 이동합니다.

프로필 페이지에 보이는 이름을 EUID***에서 username으로 수정했습니다.

프로필 페이지를 컴포넌트로 구현하는 것에 대해 생각중입니다. 현재는 로딩되는 시간동안은 username이 공백으로 보입니다.
currentUser에 대한 정보가 모두 불러와진 후 렌더링하기 위해, 컴포넌트로 만드는 것을 고민중입니다.

## 이슈
<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->
N/A
<img width="337" alt="스크린샷 2024-07-14 오전 3 15 40" src="https://github.com/user-attachments/assets/6640c338-2f2b-46d8-a8d9-61059ac0c78b">
<img width="338" alt="스크린샷 2024-07-14 오전 3 15 49" src="https://github.com/user-attachments/assets/231f15c3-8c28-48bb-b345-527e371bfcfa">
